### PR TITLE
SFSの仕様に対応

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -5,7 +5,7 @@
     "permissions": ["storage", "declarativeContent"],
     "content_scripts": [
       {
-        "matches": ["https://vu.sfc.keio.ac.jp/sfc-sfs/portal_s/s01.cgi?*&mode=0"],
+        "matches": ["https://vu.sfc.keio.ac.jp/sfc-sfs/portal_s/s01.cgi?*&mode=0*"],
         "css": ["css/mystyle.css"],
         "js": ["js/myscript.js"]
       }


### PR DESCRIPTION
ほかのページからTOPに戻ったときlang=jaが後方に移動して判定をすり抜ける問題を解消